### PR TITLE
Add fpp-WledEffects as plugin?

### DIFF
--- a/pluginList.json
+++ b/pluginList.json
@@ -46,6 +46,7 @@
 		[ "show-on-demand", "https://raw.githubusercontent.com/joeharrison714/show-on-demand-plugin/master/pluginInfo.json" ],
         [ "fpp-smartthings-plugin", "https://raw.githubusercontent.com/joeharrison714/fpp-smartthings-plugin/master/pluginInfo.json" ],
 	[ "fpp-sms-control-too", "https://raw.githubusercontent.com/joeharrison714/fpp-sms-control-too/master/pluginInfo.json" ],
-	["fpp-plugin-tplink","https://raw.githubusercontent.com/computergeek1507/fpp-plugin-tplink/main/pluginInfo.json"]
+	["fpp-plugin-tplink","https://raw.githubusercontent.com/computergeek1507/fpp-plugin-tplink/main/pluginInfo.json"],
+	["fpp-WledEffects","https://raw.githubusercontent.com/adamcoulombe/fpp-WledEffects/main/pluginInfo.json"]
 	]
 }


### PR DESCRIPTION
Hey guys...

I created a simple GUI for starting and stopping all the overlay model WLED effects. Right now its just a start, it does all the built-in WLED effects you guys added but I haven't yet added some of the other overlay effect controls in there.

Have a look and let me know what you think https://github.com/adamcoulombe/fpp-WledEffects

![wledeffects](https://user-images.githubusercontent.com/469038/146204686-99bdddca-91e8-4508-a8c8-b29c4ef07830.png)